### PR TITLE
Use defined embeds domain to serve protected embeds from

### DIFF
--- a/protected-embeds.php
+++ b/protected-embeds.php
@@ -74,7 +74,7 @@ function protected_iframe_shortcode( $attrs ) {
 		id="wpcom-iframe-<?php echo esc_attr( $attrs['id'] ) ?>"
 		width="<?php echo esc_attr( $attrs['width'] ) ?>"
 		height="<?php echo esc_attr( $attrs['height'] ) ?>"
-		src="<?php echo esc_url( '//' . PROTECTED_EMBEDS_DOMAIN . '/protected-iframe/' .  $embed->get_id() ) ?>"
+		src="<?php echo esc_url( '//' . PROTECTED_EMBEDS_DOMAIN . '/protected-iframe/' . $embed->get_id() ) ?>"
 		scrolling="<?php echo esc_attr( $attrs['scrolling'] ) ?>"
 		frameborder="0"
 		class="<?php echo esc_attr( $attrs['class'] ) ?>"

--- a/protected-embeds.php
+++ b/protected-embeds.php
@@ -74,7 +74,7 @@ function protected_iframe_shortcode( $attrs ) {
 		id="wpcom-iframe-<?php echo esc_attr( $attrs['id'] ) ?>"
 		width="<?php echo esc_attr( $attrs['width'] ) ?>"
 		height="<?php echo esc_attr( $attrs['height'] ) ?>"
-		src="<?php echo esc_url( site_url( '/protected-iframe/' . $embed->get_id() ) ) ?>"
+		src="<?php echo esc_url( path_join( '//' . PROTECTED_EMBEDS_DOMAIN, '/protected-iframe/' .  $embed->get_id() ) ) ?>"
 		scrolling="<?php echo esc_attr( $attrs['scrolling'] ) ?>"
 		frameborder="0"
 		class="<?php echo esc_attr( $attrs['class'] ) ?>"

--- a/protected-embeds.php
+++ b/protected-embeds.php
@@ -74,7 +74,7 @@ function protected_iframe_shortcode( $attrs ) {
 		id="wpcom-iframe-<?php echo esc_attr( $attrs['id'] ) ?>"
 		width="<?php echo esc_attr( $attrs['width'] ) ?>"
 		height="<?php echo esc_attr( $attrs['height'] ) ?>"
-		src="<?php echo esc_url( path_join( '//' . PROTECTED_EMBEDS_DOMAIN, '/protected-iframe/' .  $embed->get_id() ) ) ?>"
+		src="<?php echo esc_url( '//' . PROTECTED_EMBEDS_DOMAIN . '/protected-iframe/' .  $embed->get_id() ) ?>"
 		scrolling="<?php echo esc_attr( $attrs['scrolling'] ) ?>"
 		frameborder="0"
 		class="<?php echo esc_attr( $attrs['class'] ) ?>"


### PR DESCRIPTION
I assume this was the intention initially. Its important to serve these
embeds from a different domain than the site login cookie is set on, so
as to avoid leaking auth or other cookies to potentially untrusted embed
providers. This updates the src of the iframe appropriately to keep
cookies from being sent to it.

See #3