### PR TITLE
Prevent loading anything but embeds on embeds domain

### DIFF
--- a/protected-embeds.php
+++ b/protected-embeds.php
@@ -162,14 +162,14 @@ function add_rewrite_rules() {
 }
 
 function display_protected_iframe( \WP $wp ) {
-    $server = $_SERVER['HTTP_HOST'];
+	$server = $_SERVER['HTTP_HOST'];
 
-    // Prevent any output on the embeds domain other than protected iframes
-    if ( PROTECTED_EMBEDS_DOMAIN === $server && empty( $wp->query_vars['protected-iframe'] ) ) {
-        wp_die();
-    }
+	// Prevent any output on the embeds domain other than protected iframes
+	if ( PROTECTED_EMBEDS_DOMAIN === $server && empty( $wp->query_vars['protected-iframe'] ) ) {
+		wp_die();
+	}
 
-    // Don't return protected iframes on any other domain than the specified embeds domain
+	// Don't return protected iframes on any other domain than the specified embeds domain
 	if ( PROTECTED_EMBEDS_DOMAIN !== $server || empty( $wp->query_vars['protected-iframe'] ) ) {
 		return;
 	}


### PR DESCRIPTION
Adds a couple sanity checks for security:

- dies completely if the embeds domain is being used to load anything
  other than a protected iframe. This prevents it from being used to
  serve up the site, and potentially tricking a user into logging into
  the site from this domain, generating an auth cookie which can be
  sniffed.
- ensures that embeds do not render on any domain other than the
  specified embeds domain.

This needs to be merged after #4, as it doesn't make sense to block embeds from the site url until the embeds are being served from the embeds domain.

See #2