### PR TITLE
Allow filterable use of embeds domain for other content

### DIFF
--- a/protected-embeds.php
+++ b/protected-embeds.php
@@ -161,11 +161,25 @@ function add_rewrite_rules() {
 	add_rewrite_rule( '^protected-iframe/([^/]+)?', 'index.php?protected-iframe=$matches[1]', 'top' );
 }
 
+/**
+ * Whether to allow a given request to be served through the protected embeds domain.
+ *
+ * Filterable so that themes can use the embeds domain for more than the Embeds here.
+ */
+function allow_embeds_domain() {
+	global $wp;
+
+	// Prevent any output on the embeds domain other than protected iframes
+	$allow = ( ! empty( $wp->query_vars['protected-iframe'] ) );
+
+	return apply_filters( 'protected_embeds_allow_embeds_domain', $allow );
+}
+
 function display_protected_iframe( \WP $wp ) {
 	$server = $_SERVER['HTTP_HOST'];
 
 	// Prevent any output on the embeds domain other than protected iframes
-	if ( PROTECTED_EMBEDS_DOMAIN === $server && empty( $wp->query_vars['protected-iframe'] ) ) {
+	if ( PROTECTED_EMBEDS_DOMAIN === $server && ! allow_embeds_domain() ) {
 		wp_die();
 	}
 


### PR DESCRIPTION
Here's another modification we made for our purposes: now that we have an embeds domain available, we've found a number of other uses for it.

This pull adds a filter around the behavior of dying when a request for something other than a protected embed is recieved on the embeds domain. This can be used to serve other types of embeds which need to be served on a different domain from the main site.

In our theme, we've added some rules like this in order to serve iframes inside Google AMP articles:

```
/**
 * Allow the theme to use the protected embeds domain to serve iframes
 * using the endpoint `/cta/{name}/`.
 */
add_filter( 'protected_embeds_allow_embeds_domain', function( $allow ) {
    global $wp;

    // Allow serving CTAs from embeds domain
    if ( ! empty( $wp->query_vars['cta'] ) ) {
        $allow = true;
    }

    return $allow;
} );
``` 