### PR TITLE
Prevent fatal error if Embed::get returns null in display_protected_iframe

### DIFF
--- a/protected-embeds.php
+++ b/protected-embeds.php
@@ -179,8 +179,8 @@ function display_protected_iframe( \WP $wp ) {
 	$embed = Embed::get( $wp->query_vars['protected-iframe'] );
 
 	if ( ! $embed ) {
-	    return;
-    }
+		return;
+	}
 	?>
 	<html>
 		<head>

--- a/protected-embeds.php
+++ b/protected-embeds.php
@@ -178,6 +178,9 @@ function display_protected_iframe( \WP $wp ) {
 
 	$embed = Embed::get( $wp->query_vars['protected-iframe'] );
 
+	if ( ! $embed ) {
+	    return;
+    }
 	?>
 	<html>
 		<head>


### PR DESCRIPTION
The function `Embed::get()` can return null.  This possibility is handled in `protected_iframe_shortcode()` but is not handled in `display_protected_iframe()`

The call stack for such an error looks like:

```
[27-May-2021 19:32:32 UTC] Fatal error: Uncaught Error: Call to a member function get_html() on null in /var/www/wp-content/plugins/protected-embeds/protected-embeds.php:191
Stack trace:
#0 /var/www/wp-includes/class-wp-hook.php(292): Protected_Embeds\display_protected_iframe(Object(WP))
#1 /var/www/wp-includes/class-wp-hook.php(316): WP_Hook->apply_filters(NULL, Array)
#2 /var/www/wp-includes/plugin.php(551): WP_Hook->do_action(Array)
#3 /var/www/wp-includes/class-wp.php(388): do_action_ref_array('parse_request', Array)
#4 /var/www/wp-includes/class-wp.php(750): WP->parse_request('')
#5 /var/www/wp-includes/functions.php(1291): WP->main('')
#6 /var/www/wp-blog-header.php(16): wp()
#7 /var/www/index.php(17): require('/var/www/wp-blo...')
#8 {main}
  thrown in /var/www/wp-content/plugins/protected-embeds/protected-embeds.php on line 191
```